### PR TITLE
Fix misplaced scripts in base template

### DIFF
--- a/_site/bio/index.html
+++ b/_site/bio/index.html
@@ -36,24 +36,23 @@
       <p>&copy; Bio — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="/scripts/three.r134.min.js"></script>
+  <script src="/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="/scripts/three.r134.min.js"></script>
-<script src="/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>

--- a/_site/blog/2025-06-29-test-page/index.html
+++ b/_site/blog/2025-06-29-test-page/index.html
@@ -39,24 +39,23 @@
       <p>&copy; Test page — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="/scripts/three.r134.min.js"></script>
+  <script src="/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="/scripts/three.r134.min.js"></script>
-<script src="/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>

--- a/_site/blog/index.html
+++ b/_site/blog/index.html
@@ -42,24 +42,23 @@
       <p>&copy; Blog — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="/scripts/three.r134.min.js"></script>
+  <script src="/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="/scripts/three.r134.min.js"></script>
-<script src="/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>

--- a/_site/index.html
+++ b/_site/index.html
@@ -45,24 +45,23 @@
       <p>&copy; Creature Rock — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="/scripts/three.r134.min.js"></script>
+  <script src="/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="/scripts/three.r134.min.js"></script>
-<script src="/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>

--- a/_site/media/index.html
+++ b/_site/media/index.html
@@ -45,24 +45,23 @@
       <p>&copy; Media — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="/scripts/three.r134.min.js"></script>
+  <script src="/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="/scripts/three.r134.min.js"></script>
-<script src="/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>

--- a/_site/projects/circle-and-spiral/index.html
+++ b/_site/projects/circle-and-spiral/index.html
@@ -35,24 +35,23 @@
       <p>&copy; Circle and Spiral — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="/scripts/three.r134.min.js"></script>
+  <script src="/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="/scripts/three.r134.min.js"></script>
-<script src="/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -46,24 +46,23 @@
       <p>&copy; {{ title }} — Creature Rock transmissions</p>
     </footer>
   </div>
+  <script src="{{ site.baseurl }}/scripts/three.r134.min.js"></script>
+  <script src="{{ site.baseurl }}/scripts/vanta.fog.min.js"></script>
+  <script>
+  VANTA.FOG({
+    el: "#background-layer",
+    mouseControls: true,
+    touchControls: true,
+    gyroControls: false,
+    minHeight: 200.00,
+    minWidth: 200.00,
+    highlightColor: 0x743ab1,
+    midtoneColor: 0x661db9,
+    lowlightColor: 0x1b0c1b,
+    baseColor: 0xd1c6f0,
+    blurFactor: 0.45,
+    speed: 0.15
+  })
+  </script>
 </body>
 </html>
-
-<script src="{{ site.baseurl }}/scripts/three.r134.min.js"></script>
-<script src="{{ site.baseurl }}/scripts/vanta.fog.min.js"></script>
-<script>
-VANTA.FOG({
-  el: "#background-layer",
-  mouseControls: true,
-  touchControls: true,
-  gyroControls: false,
-  minHeight: 200.00,
-  minWidth: 200.00,
-  highlightColor: 0x743ab1,
-  midtoneColor: 0x661db9,
-  lowlightColor: 0x1b0c1b,
-  baseColor: 0xd1c6f0,
-  blurFactor: 0.45,
-  speed: 0.15
-})
-</script>


### PR DESCRIPTION
## Summary
- move background effect scripts inside the `<body>`
- rebuild static site to include the fix

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687253a5144c8324aa960c754edcd44c