### PR TITLE
Add Press Kit page and golden nav styling

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -20,6 +20,7 @@
         <a href="{{ site.baseurl }}/projects/">Projects</a>
         <a href="{{ site.baseurl }}/media/">Media</a>
         <a href="{{ site.baseurl }}/blog/">Blog</a>
+        <a href="{{ site.baseurl }}/press-kit/">Press Kit</a>
       </nav>
     </header>
 

--- a/src/pages/press-kit.md
+++ b/src/pages/press-kit.md
@@ -1,0 +1,7 @@
+---
+title: Press Kit
+layout: base.njk
+hero_image: /images/avatar_cherry_blossom.png
+permalink: "{{ site.baseurl }}/press-kit/"
+---
+Download high-resolution photos, biographies, and contact info for press inquiries.

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,18 +38,20 @@ nav {
   justify-content: center;
   gap: 1.5rem;
   margin-bottom: 2rem;
+  border-bottom: 3px solid #d4af37;
+  padding-bottom: 0.5rem;
 }
 
 nav a {
   text-decoration: none;
-  color: #333;
+  color: #b8860b;
   font-weight: 700;
   font-family: 'Montserrat', sans-serif;
   letter-spacing: 0.05em;
 }
 
 nav a:hover {
-  color: #000;
+  color: #8b6508;
 }
 
 .site-main {


### PR DESCRIPTION
## Summary
- add Press Kit page to the pages collection
- include Press Kit link in navigation
- add subtle gold color styling to menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687292e5470483249f41e4fec601c3dc